### PR TITLE
make link in content multiline and not one long line

### DIFF
--- a/src/app/[lng]/Components/ResultComp/AccordionContent.tsx
+++ b/src/app/[lng]/Components/ResultComp/AccordionContent.tsx
@@ -117,7 +117,7 @@ export default function AccordionContent({
                                             textDecoration: "underline",
                                         }}
                                     >
-                                        {data.link}
+                                        {t("common.link_title")}
                                     </Link>
                                 </Box>
                             )}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -39,7 +39,8 @@
         "email": "Email",
         "password": "Password",
         "description": "Description",
-        "invalid_link": "Invalid link"
+        "invalid_link": "Invalid link",
+        "link_title": "For the link click here"
     },
     "errors": {
         "error_occured": "An error occurred",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -41,7 +41,8 @@
         "reported_mistake": "דיווח על טעות",
         "name": "שם",
         "yes": "כן",
-        "no": "לא"
+        "no": "לא",
+        "link_title": "לקישור לחץ כאן"
     },
     "errors": {
         "error_occured": "אירעה שגיאה",


### PR DESCRIPTION
Fixes #80
ending up changing the link label for a common label instead